### PR TITLE
fix: minimum chance for duckdice

### DIFF
--- a/src/public/js/DuckDice/info.js
+++ b/src/public/js/DuckDice/info.js
@@ -30,7 +30,7 @@ function checkParams(p,ch){
     if(p < 0.00000001 || p > 1000000000*1000000000) {
         return false
     }
-    if(ch>98 || ch<1) {
+    if(ch>98 || ch<0.01) {
         return false
     }
     return true;


### PR DESCRIPTION
Allow users to set the `chance` below 1%.

closes #60