### PR TITLE
fix: stopOnWin and stopOnLoss

### DIFF
--- a/src/views/info.pug
+++ b/src/views/info.pug
@@ -1936,6 +1936,8 @@ block content
                         }
                         nextbet = basebet;
                         isloop = true;
+                        stopOnWin = false;
+                        stopOnLoss = false;
                         $$("script_bet_start_stop_button").setValue('STOP');
                         scriptBet(true);
                     });


### PR DESCRIPTION
Squash the  bug that forces users to reload after using  `Stop On Next Win` and `Stop On Next Loss` button.